### PR TITLE
乱数を生成するとき引数の最大値が戻り値に含まれない問題の修正

### DIFF
--- a/src/interpreter/lib/std.ts
+++ b/src/interpreter/lib/std.ts
@@ -261,7 +261,7 @@ export const std: Record<string, Value> = {
 
 		return FN_NATIVE(([min, max]) => {
 			if (min && min.type === 'num' && max && max.type === 'num') {
-				return NUM(Math.floor(rng() * (Math.floor(max.value) - Math.ceil(min.value)) + Math.ceil(min.value)));
+				return NUM(Math.floor(rng() * (Math.floor(max.value) - Math.ceil(min.value) + 1) + Math.ceil(min.value)));
 			}
 			return NUM(rng());
 		});


### PR DESCRIPTION
# What
乱数を生成するとき引数の最大値を戻り値に含むように

# Why
ドキュメントでは `min および max を渡した場合、min <= x, x <= max の整数` が生成されることになっているが、#247  から `max` の値が戻り値に含まれなくなってしまった。
#255 の修正に漏れがあった。

# Additional info
この問題により一部の Play が意図した動作をしなくなってしまいました。
#255 の漏れは私の確認不足です。[ご指摘いただいた](https://misskey.io/notes/9eo4tlhjxr) ririri さんに感謝申し上げます。
皆様にご迷惑をおかけしましたことをお詫び申し上げるとともに、この PR で修正させていただきます。