### PR TITLE
Returnの方式の変更

### DIFF
--- a/etc/aiscript.api.md
+++ b/etc/aiscript.api.md
@@ -172,9 +172,6 @@ type Bool_2 = NodeBase_2 & ChainProp & {
 };
 
 // @public (undocumented)
-const BREAK: () => Value;
-
-// @public (undocumented)
 type Break = NodeBase & {
     type: 'break';
 };
@@ -219,9 +216,6 @@ type CallChain = NodeBase_2 & {
 
 // @public (undocumented)
 type ChainMember = CallChain | IndexChain | PropChain;
-
-// @public (undocumented)
-const CONTINUE: () => Value;
 
 // @public (undocumented)
 type Continue = NodeBase & {
@@ -743,9 +737,6 @@ type PropChain = NodeBase_2 & {
 };
 
 // @public (undocumented)
-const RETURN: (v: VReturn['value']) => Value;
-
-// @public (undocumented)
 type Return = NodeBase & {
     type: 'return';
     expr: Expression;
@@ -859,9 +850,6 @@ type TypeSource = NamedTypeSource | FnTypeSource;
 // @public (undocumented)
 type TypeSource_2 = NamedTypeSource_2 | FnTypeSource_2;
 
-// @public (undocumented)
-const unWrapRet: (v: Value) => Value;
-
 declare namespace utils {
     export {
         expectAny,
@@ -893,7 +881,7 @@ function valToJs(val: Value): any;
 function valToString(val: Value, simple?: boolean): string;
 
 // @public (undocumented)
-type Value = (VNull | VBool | VNum | VStr | VArr | VObj | VFn | VReturn | VBreak | VContinue) & Attr_2;
+type Value = (VNull | VBool | VNum | VStr | VArr | VObj | VFn) & Attr_2;
 
 declare namespace values {
     export {
@@ -904,9 +892,6 @@ declare namespace values {
         VArr,
         VObj,
         VFn,
-        VReturn,
-        VBreak,
-        VContinue,
         Attr_2 as Attr,
         Value,
         NULL,
@@ -918,11 +903,7 @@ declare namespace values {
         OBJ,
         ARR,
         FN,
-        FN_NATIVE,
-        RETURN,
-        BREAK,
-        CONTINUE,
-        unWrapRet
+        FN_NATIVE
     }
 }
 export { values }
@@ -937,18 +918,6 @@ type VArr = {
 type VBool = {
     type: 'bool';
     value: boolean;
-};
-
-// @public (undocumented)
-type VBreak = {
-    type: 'break';
-    value: null;
-};
-
-// @public (undocumented)
-type VContinue = {
-    type: 'continue';
-    value: null;
 };
 
 // @public (undocumented)
@@ -979,12 +948,6 @@ type VNum = {
 type VObj = {
     type: 'obj';
     value: Map<string, Value>;
-};
-
-// @public (undocumented)
-type VReturn = {
-    type: 'return';
-    value: Value;
 };
 
 // @public (undocumented)

--- a/etc/aiscript.api.md
+++ b/etc/aiscript.api.md
@@ -185,6 +185,13 @@ type Break_2 = NodeBase_2 & {
 };
 
 // @public (undocumented)
+class BreakError extends AiScriptError {
+    constructor(nodeType: 'break' | 'continue', message: string, info?: any);
+    // (undocumented)
+    nodeType: 'break' | 'continue';
+}
+
+// @public (undocumented)
 function CALL(target: Call_2['target'], args: Call_2['args'], loc?: {
     start: number;
     end: number;
@@ -324,7 +331,9 @@ declare namespace errors {
         SyntaxError_2 as SyntaxError,
         TypeError_2 as TypeError,
         RuntimeError,
-        IndexOutOfRangeError
+        IndexOutOfRangeError,
+        ReturnError,
+        BreakError
     }
 }
 export { errors }
@@ -747,6 +756,15 @@ type Return_2 = NodeBase_2 & {
     type: 'return';
     expr: Expression_2;
 };
+
+// @public (undocumented)
+class ReturnError extends AiScriptError {
+    constructor(val: Value, message: string, info?: any);
+    // (undocumented)
+    nodeType: string;
+    // (undocumented)
+    val: Value;
+}
 
 // @public (undocumented)
 class RuntimeError extends AiScriptError {

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,3 +1,5 @@
+import type { Value } from './interpreter/value';
+
 export abstract class AiScriptError extends Error {
 	public info?: any;
 
@@ -33,6 +35,30 @@ export class RuntimeError extends AiScriptError {
 
 export class IndexOutOfRangeError extends RuntimeError {
 	constructor(message: string, info?: any) {
+		super(message, info);
+	}
+}
+
+// return文でスコープ抜け出しを行う用
+// 関数定義ブロックがcatchしなかったらそのままエラーとして扱う
+export class ReturnError extends AiScriptError {
+	public nodeType = 'return';
+	constructor(
+		public val: Value,
+		message: string,
+		info?: any,
+	) {
+		super(message, info);
+	}
+}
+// break/continue文でスコープ抜け出しを行う用
+// loop/for/eachがcatchしなかったらそのままエラーとして扱う
+export class BreakError extends AiScriptError {
+	constructor(
+		public nodeType: 'break'|'continue',
+		message: string,
+		info?: any,
+	) {
 		super(message, info);
 	}
 }

--- a/src/interpreter/util.ts
+++ b/src/interpreter/util.ts
@@ -129,7 +129,7 @@ export function valToJs(val: Value): any {
 			return obj;
 		}
 		case 'str': return val.value;
-		default: throw new Error(`Unrecognized value type: ${val.type}`);
+		//default: throw new Error(`Unrecognized value type: ${val.type}`);
 	}
 }
 

--- a/src/interpreter/value.ts
+++ b/src/interpreter/value.ts
@@ -42,21 +42,6 @@ export type VFn = {
 	scope?: Scope;
 };
 
-export type VReturn = {
-	type: 'return';
-	value: Value;
-};
-
-export type VBreak = {
-	type: 'break';
-	value: null;
-};
-
-export type VContinue = {
-	type: 'continue';
-	value: null;
-};
-
 export type Attr = {
 	attr?: {
 		name: string;
@@ -64,7 +49,7 @@ export type Attr = {
 	}[];
 };
 
-export type Value = (VNull | VBool | VNum | VStr | VArr | VObj | VFn | VReturn | VBreak | VContinue) & Attr;
+export type Value = (VNull | VBool | VNum | VStr | VArr | VObj | VFn ) & Attr;
 
 export const NULL = {
 	type: 'null' as const,
@@ -116,21 +101,3 @@ export const FN_NATIVE = (fn: VFn['native']): VFn => ({
 	type: 'fn' as const,
 	native: fn,
 });
-
-// Return文で値が返されたことを示すためのラッパー
-export const RETURN = (v: VReturn['value']): Value => ({
-	type: 'return' as const,
-	value: v,
-});
-
-export const BREAK = (): Value => ({
-	type: 'break' as const,
-	value: null,
-});
-
-export const CONTINUE = (): Value => ({
-	type: 'continue' as const,
-	value: null,
-});
-
-export const unWrapRet = (v: Value): Value => v.type === 'return' ? v.value : v;


### PR DESCRIPTION
# What
従来のRETURN/BREAK/CONTINUE型を廃し、新しく例外機構を利用したreturn/break/continueの処理を実装します。

# Why
- RETURN型が不要になることにより、returnのラッパーが取り出せてしまう問題が解決します。<br>→solve #237<br>→solve #268
- #276 の「値を返す・返さない関係なく、return系は現在のスコープを破棄し親スコープに処理を移動する」が実現されます。
- 不正なコードである「関数定義ブロック外のreturn」、「ループ外のbreak/continue」にエラーを出すことができます。

# Additional info (optional)
> 不正なコードである「関数定義ブロック外のreturn」、「ループ外のbreak/continue」にエラーを出すことができます。

・あくまで評価時のエラーになるため、実行時に評価されない位置にある不正return/breakはエラーになりません。
例：
```
loop {
 break
 return 1 //評価されない
}
```
・今回の実装だと「breakを含む関数」の存在が許容されることになります。
例：
```
@func(){
 break
}
loop {
 func() //breakとしてはたらく
}
```
これらは後々修正したほうがいいかもしれません。