### PR TITLE
パーサーのテンプレートの部分を改修

### DIFF
--- a/src/parser/parser.peggy
+++ b/src/parser/parser.peggy
@@ -1,36 +1,4 @@
 {
-	function group(arr, predicate) {
-		const dest = [];
-
-		for (let i = 0; i < arr.length; i++) {
-			if (i != 0 && predicate(arr[i - 1], arr[i])) {
-				dest[dest.length - 1].push(arr[i]);
-			} else {
-				dest.push([arr[i]]);
-			}
-		}
-
-		return dest;
-	}
-
-	function ungroup(groupes) {
-		return groupes.reduce((acc, val) => acc.concat(val), []);
-	}
-
-	function concatTemplate(arr) {
-		let groupes = group(arr, (prev, current) => (typeof current == typeof prev));
-
-		// concat string
-		groupes = groupes.map(g => {
-			if (typeof g[0] == 'string') {
-				return [g.join('')];
-			}
-			return g;
-		});
-
-		return ungroup(groupes);
-	}
-
 	function createNode(type, params, children) {
 		const node = { type };
 		params.children = children;
@@ -415,19 +383,19 @@ Identifier
 // template literal
 
 Tmpl
-	= "`" items:(!"`" i:TmplEmbed { return i; })* "`"
-{ return createNode('tmpl', { tmpl: concatTemplate(items) }); }
+	= "`" items:(!"`" @TmplEmbed)* "`"
+{ return createNode('tmpl', { tmpl: items }); }
 
 TmplEmbed
-	= TmplEsc
-	/ "{" __* expr:Expr __* "}"
-{ return expr; }
-	/ .
+	= "{" __* @expr:Expr __* "}"
+	/ str:TmplAtom+ {return str.join("")}
+
+TmplAtom
+  = TmplEsc
+	/ [^`{]
 
 TmplEsc
-	= "\\{" { return text()[1]; } // avoid syntax error of PEG.js (bug?)
-	/ "\\}" { return text()[1]; } // avoid syntax error of PEG.js (bug?)
-	/ "\\`" { return '`'; }
+	= "\\" @[{}`]
 
 // string literal
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -957,6 +957,18 @@ describe('Template syntax', () => {
 		eq(res, STR('1 + 1 = 2'));
 	});
 
+	test.concurrent('invalid', async () => {
+		try {
+			await exe(`
+			<: \`{hoge}\`
+			`);
+		} catch (e) {
+			assert.ok(true);
+			return;
+		}
+		assert.fail();
+	});
+
 	test.concurrent('Escape', async () => {
 		const res = await exe(`
 		let message = "Hello"
@@ -966,7 +978,7 @@ describe('Template syntax', () => {
 	});
 });
 
-test.concurrent('Throws error when divied by zero', async () => {
+test.concurrent('Throws error when divided by zero', async () => {
 	try {
 		await exe(`
 		<: (0 / 0)
@@ -2491,8 +2503,8 @@ describe('std', () => {
 				let random = Math:gen_rng(seed)
 				return random(0 100)
 			}
-			let seed1 = \`{@Util:uuid()}\`
-			let seed2 = \`{@Date:year()}\`
+			let seed1 = \`{Util:uuid()}\`
+			let seed2 = \`{Date:year()}\`
 			let test1 = if (test(seed1) == test(seed1)) {true} else {false}
 			let test2 = if (test(seed1) == test(seed2)) {true} else {false}
 			<: [test1 test2]


### PR DESCRIPTION
parser.peggyのTmplの定義を、
- {}の中身が無効な文字列だった場合、パースエラーになるようにしました。
- 関数を使わないような形に簡略化しました。

ついでにテストを少し修正しました。