### PR TITLE
PlaygroundでSyntax Errorの発生箇所を表示するように

### DIFF
--- a/playground/src/App.vue
+++ b/playground/src/App.vue
@@ -8,7 +8,7 @@
 				<PrismEditor class="code" v-model="script" :highlight="highlighter" :line-numbers="false"/>
 			</div>
 			<footer>
-				<span v-if="isSyntaxError" class="syntaxError">Syntax Error!</span>
+				<span v-if="syntaxErrorMessage" class="syntaxError">{{ syntaxErrorMessage }}</span>
 				<div class="actions"><button @click="run">RUN</button></div>
 			</footer>
 		</div>
@@ -56,16 +56,16 @@ const script = ref(window.localStorage.getItem('script') || '<: "Hello, AiScript
 
 const ast = ref(null);
 const logs = ref([]);
-const isSyntaxError = ref(false);
+const syntaxErrorMessage = ref(null);
 
 watch(script, () => {
 	window.localStorage.setItem('script', script.value);
 	try {
 		ast.value = Parser.parse(script.value);
-		isSyntaxError.value = false;
+		syntaxErrorMessage.value = null;
 	} catch (e) {
-		isSyntaxError.value = true;
-		console.error(e);
+		syntaxErrorMessage.value = e.message;
+		console.error(e.info);
 		return;
 	}
 }, {

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -65,9 +65,9 @@ export class Parser {
 		} catch (e) {
 			if (e.location) {
 				if (e.expected) {
-					throw new SyntaxError(`Parsing error. (Line ${e.location.start.line}:${e.location.start.column})`);
+					throw new SyntaxError(`Parsing error. (Line ${e.location.start.line}:${e.location.start.column})`, e);
 				} else {
-					throw new SyntaxError(`${e.message} (Line ${e.location.start.line}:${e.location.start.column})`);
+					throw new SyntaxError(`${e.message} (Line ${e.location.start.line}:${e.location.start.column})`, e);
 				}
 			}
 			throw e;


### PR DESCRIPTION
Playgroundで従来ただ"Syntax Error!"と表示されていた場所にエラーの行数の情報を付加します。