### PR TITLE
オブジェクトの要素を配列と同じ構文で参照可能に

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 [Read translated version (en)](./translations/en/CHANGELOG.md)
 
 - `Core:to_str`, `テンプレート文字列` でどの値でも文字列へ変換できるように
-
 - 指定時間待機する関数`Core:sleep`を追加
 - `exists 変数名` の構文で変数が存在するか判定できるように
+- オブジェクトを添字で参照できるように（`object['index']`のように）
 
 # 0.15.0
 - Mathを強化

--- a/src/interpreter/index.ts
+++ b/src/interpreter/index.ts
@@ -392,14 +392,24 @@ export class Interpreter {
 
 			case 'index': {
 				const target = await this._eval(node.target, scope);
-				assertArray(target);
 				const i = await this._eval(node.index, scope);
-				assertNumber(i);
-				const item = target.value[i.value];
-				if (item === undefined) {
-					throw new IndexOutOfRangeError(`Index out of range. index: ${i.value} max: ${target.value.length - 1}`);
+				if (isArray(target)) {
+					assertNumber(i);
+					const item = target.value[i.value];
+					if (item === undefined) {
+						throw new IndexOutOfRangeError(`Index out of range. index: ${i.value} max: ${target.value.length - 1}`);
+					}
+					return item;
+				} else if (isObject(target)) {
+					assertString(i);
+					if (target.value.has(i.value)) {
+						return target.value.get(i.value)!;
+					} else {
+						return NULL;
+					}
+				} else {
+					throw new RuntimeError(`Cannot read prop (${reprValue(i)}) of ${target.type}.`);
 				}
-				return item;
 			}
 
 			case 'not': {
@@ -540,12 +550,16 @@ export class Interpreter {
 			scope.assign(dest.name, value);
 		} else if (dest.type === 'index') {
 			const assignee = await this._eval(dest.target, scope);
-			assertArray(assignee);
-
 			const i = await this._eval(dest.index, scope);
-			assertNumber(i);
-
-			assignee.value[i.value] = value; // TODO: 存在チェック
+			if (isArray(assignee)) {
+				assertNumber(i);
+				assignee.value[i.value] = value; // TODO: 存在チェック
+			} else if (isObject(assignee)) {
+				assertString(i);
+				assignee.value.set(i.value, value);
+			} else {
+				throw new RuntimeError(`Cannot read prop (${reprValue(i)}) of ${assignee.type}.`);
+			}
 		} else if (dest.type === 'prop') {
 			const assignee = await this._eval(dest.target, scope);
 			assertObject(assignee);

--- a/test/index.ts
+++ b/test/index.ts
@@ -1048,6 +1048,14 @@ describe('chain', () => {
 		`);
 		eq(res, NUM(45));
 	});
+
+	test.concurrent('object with index', async () => {
+		const res = await exe(`
+		let ai = {a: {}}['a']
+		ai['chan'] = 'kawaii'
+		<: ai[{a: 'chan'}['a']]
+		`);
+		eq(res, STR('kawaii'));
 });
 
 describe('Template syntax', () => {


### PR DESCRIPTION
```
object['index']
```
の形でオブジェクトの要素を取得できるようにします。
## why
`Obj:get(object, 'index')`より直感的な形式を提供するため。