### PR TITLE
Interpreterのコンストラクタ引数を以前同様に戻す

### DIFF
--- a/etc/aiscript.api.md
+++ b/etc/aiscript.api.md
@@ -528,8 +528,7 @@ type InfixOperator = '||' | '&&' | '==' | '!=' | '<=' | '>=' | '<' | '>' | '+' |
 
 // @public (undocumented)
 export class Interpreter {
-    // Warning: (ae-forgotten-export) The symbol "Variable" needs to be exported by the entry point index.d.ts
-    constructor(vars: Record<string, Variable>, opts?: {
+    constructor(consts: Record<string, Value>, opts?: {
         in?(q: string): Promise<string>;
         out?(value: Value): void;
         log?(type: string, params: Record<string, any>): void;
@@ -816,6 +815,8 @@ export class Scope {
     constructor(layerdStates?: Scope['layerdStates'], parent?: Scope, name?: Scope['name']);
     add(name: string, variable: Variable): void;
     assign(name: string, val: Value): void;
+    // Warning: (ae-forgotten-export) The symbol "Variable" needs to be exported by the entry point index.d.ts
+    //
     // (undocumented)
     createChildScope(states?: Map<string, Variable>, name?: Scope['name']): Scope;
     exists(name: string): boolean;

--- a/src/interpreter/index.ts
+++ b/src/interpreter/index.ts
@@ -9,9 +9,9 @@ import { std } from './lib/std.js';
 import { assertNumber, assertString, assertFunction, assertBoolean, assertObject, assertArray, eq, isObject, isArray, expectAny, reprValue } from './util.js';
 import { NULL, RETURN, unWrapRet, FN_NATIVE, BOOL, NUM, STR, ARR, OBJ, FN, BREAK, CONTINUE } from './value.js';
 import { getPrimProp } from './primitive-props.js';
+import { Variable } from './variable.js';
 import type { Value, VFn } from './value.js';
 import type * as Ast from '../node.js';
-import { Variable } from './variable.js';
 
 const IRQ_RATE = 300;
 const IRQ_AT = IRQ_RATE - 1;
@@ -46,13 +46,11 @@ export class Interpreter {
 			}),
 		};
 
-		this.vars = Object.fromEntries(
-			Object.entries({
-				...consts,
-				...std,
-				...io,
-			}).map(([k, v]) => [k, Variable.const(v)])
-		);
+		this.vars = Object.fromEntries(Object.entries({
+			...consts,
+			...std,
+			...io,
+		}).map(([k, v]) => [k, Variable.const(v)]));
 
 		this.scope = new Scope([new Map(Object.entries(this.vars))]);
 		this.scope.opts.log = (type, params): void => {


### PR DESCRIPTION
#329 でInterpreterに渡す初期変数の型が`Record<string, Variable>`に変わりましたが、こちらもstd定数同様まとめてラップしてしまったほうが都合がよいと思ったので`Record<string, Value>`に戻します。