### PR TITLE
dependabotのPRをひとまとめにする

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,15 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      all:
+        patterns:
+          - "*"
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    groups:
+      all:
+        patterns:
+          - "*"


### PR DESCRIPTION
最近追加されたらしいdependabotのGrouped version updates機能を使用します。
※ベータ版らしい？
c.f.
- https://zenn.dev/yuki0920/articles/9af3a7581193bf
- https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups