### PR TITLE
Revert "Bump codecov/codecov-action from 3 to 4"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,4 +37,4 @@ jobs:
           CI: true
 
       - name: Upload Coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3


### PR DESCRIPTION
Reverts syuilo/aiscript#350
## Why
Test and Coverage が失敗するため。
https://github.com/syuilo/aiscript/actions/runs/6212130393
参考：
https://github.com/codecov/codecov-action/issues/1091