### PR TITLE
playgroundの内部的な改良

### DIFF
--- a/playground/package-lock.json
+++ b/playground/package-lock.json
@@ -8,6 +8,7 @@
       "name": "aiscript-playground",
       "version": "0.0.0",
       "dependencies": {
+        "@syuilo/aiscript": "file:..",
         "prismjs": "^1.29.0",
         "vite": "^2.9.16",
         "vue": "^3.0.5",
@@ -16,6 +17,35 @@
       "devDependencies": {
         "@vitejs/plugin-vue": "^1.3.0",
         "@vue/compiler-sfc": "^3.0.5"
+      }
+    },
+    "..": {
+      "version": "0.16.0",
+      "license": "MIT",
+      "dependencies": {
+        "seedrandom": "3.0.5",
+        "stringz": "2.1.0",
+        "uuid": "9.0.1"
+      },
+      "devDependencies": {
+        "@microsoft/api-extractor": "7.37.0",
+        "@types/jest": "29.5.5",
+        "@types/node": "20.6.2",
+        "@types/seedrandom": "3.0.5",
+        "@types/uuid": "9.0.4",
+        "@typescript-eslint/eslint-plugin": "6.7.2",
+        "@typescript-eslint/parser": "6.7.2",
+        "chalk": "5.3.0",
+        "copyfiles": "2.4.1",
+        "eslint": "8.49.0",
+        "eslint-plugin-import": "2.28.1",
+        "jest": "29.7.0",
+        "peggy": "3.0.2",
+        "ts-jest": "29.1.1",
+        "ts-jest-resolver": "2.0.1",
+        "ts-node": "10.9.1",
+        "tsd": "0.29.0",
+        "typescript": "5.2.2"
       }
     },
     "node_modules/@babel/parser": {
@@ -48,6 +78,10 @@
       "version": "1.4.15",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
       "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
+    },
+    "node_modules/@syuilo/aiscript": {
+      "resolved": "..",
+      "link": true
     },
     "node_modules/@vitejs/plugin-vue": {
       "version": "1.10.2",

--- a/playground/package.json
+++ b/playground/package.json
@@ -8,6 +8,7 @@
     "serve": "vite preview"
   },
   "dependencies": {
+    "@syuilo/aiscript": "file:..",
     "prismjs": "^1.29.0",
     "vite": "^2.9.16",
     "vue": "^3.0.5",

--- a/playground/src/App.vue
+++ b/playground/src/App.vue
@@ -1,6 +1,6 @@
 <template>
 <div id="root">
-	<h1>AiScript (v0.16.0) Playground</h1>
+	<h1>AiScript (v{{ std['Core:v'].value }}) Playground</h1>
 	<div id="grid1">
 		<div id="editor" class="container">
 			<header>Input<div class="actions"><button @click="setCode">FizzBuzz</button></div></header>
@@ -42,7 +42,8 @@
 
 <script setup>
 import { ref, watch } from 'vue';
-import { Interpreter, Parser, utils } from '../../src';
+import { Interpreter, Parser, utils } from '@syuilo/aiscript';
+import { std } from '@syuilo/aiscript/interpreter/lib/std';
 
 import { PrismEditor } from 'vue-prism-editor';
 import 'vue-prism-editor/dist/prismeditor.min.css';

--- a/playground/vite.config.js
+++ b/playground/vite.config.js
@@ -3,6 +3,11 @@ import vue from '@vitejs/plugin-vue'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-	base: '/aiscript/',
-  plugins: [vue()]
+	base: './',
+  plugins: [vue()],
+	server: {
+		fs: {
+			allow: [ '..' ]
+		}
+	},
 })


### PR DESCRIPTION
- AiScriptをnpm経由で参照する　→AiScriptがパッケージとして機能しているかの確認のため
- バージョンをCore:vから取得（専用の定数をexportすべき？）
- vite.config.jsのbaseを相対パスに（他のリポジトリで試したら問題なく動いた）　→リポジトリ名を変更しているForkでも設定を変えずにpagesをデプロイ出来るようにするため