### PR TITLE
文法エラーに位置情報を追加

### DIFF
--- a/etc/aiscript.api.md
+++ b/etc/aiscript.api.md
@@ -45,7 +45,9 @@ class AiScriptSyntaxError extends AiScriptError {
 
 // @public
 class AiScriptTypeError extends AiScriptError {
-    constructor(message: string, info?: any);
+    constructor(message: string, loc: Loc, info?: any);
+    // (undocumented)
+    loc: Loc;
     // (undocumented)
     name: string;
 }

--- a/etc/aiscript.api.md
+++ b/etc/aiscript.api.md
@@ -36,7 +36,9 @@ class AiScriptRuntimeError extends AiScriptError {
 
 // @public
 class AiScriptSyntaxError extends AiScriptError {
-    constructor(message: string, info?: any);
+    constructor(message: string, loc: Loc, info?: any);
+    // (undocumented)
+    loc: Loc;
     // (undocumented)
     name: string;
 }

--- a/src/error.ts
+++ b/src/error.ts
@@ -41,8 +41,8 @@ export class AiScriptSyntaxError extends AiScriptError {
  */ 
 export class AiScriptTypeError extends AiScriptError {
 	public name = 'Type';
-	constructor(message: string, info?: any) {
-		super(message, info);
+	constructor(message: string, public loc: Loc, info?: any) {
+		super(`${message} (Line ${loc.line}, Column ${loc.column}`, info);
 	}
 }
 

--- a/src/error.ts
+++ b/src/error.ts
@@ -33,7 +33,7 @@ export class NonAiScriptError extends AiScriptError {
 export class AiScriptSyntaxError extends AiScriptError {
 	public name = 'Syntax';
 	constructor(message: string, public loc: Loc, info?: any) {
-		super(`${message} (Line ${loc.line}, Column ${loc.column}`, info);
+		super(`${message} (Line ${loc.line}, Column ${loc.column})`, info);
 	}
 }
 /**
@@ -42,7 +42,7 @@ export class AiScriptSyntaxError extends AiScriptError {
 export class AiScriptTypeError extends AiScriptError {
 	public name = 'Type';
 	constructor(message: string, public loc: Loc, info?: any) {
-		super(`${message} (Line ${loc.line}, Column ${loc.column}`, info);
+		super(`${message} (Line ${loc.line}, Column ${loc.column})`, info);
 	}
 }
 

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,3 +1,5 @@
+import type { Loc } from './node.js';
+
 export abstract class AiScriptError extends Error {
 	// name is read by Error.prototype.toString
 	public name = 'AiScript';
@@ -30,8 +32,8 @@ export class NonAiScriptError extends AiScriptError {
  */
 export class AiScriptSyntaxError extends AiScriptError {
 	public name = 'Syntax';
-	constructor(message: string, info?: any) {
-		super(message, info);
+	constructor(message: string, public loc: Loc, info?: any) {
+		super(`${message} (Line ${loc.line}, Column ${loc.column}`, info);
 	}
 }
 /**

--- a/src/parser/plugins/validate-keyword.ts
+++ b/src/parser/plugins/validate-keyword.ts
@@ -42,8 +42,8 @@ const reservedWord = [
 	// 'out',
 ];
 
-function throwReservedWordError(name: string): void {
-	throw new AiScriptSyntaxError(`Reserved word "${name}" cannot be used as variable name.`);
+function throwReservedWordError(name: string, loc: Ast.Loc): void {
+	throw new AiScriptSyntaxError(`Reserved word "${name}" cannot be used as variable name.`, loc);
 }
 
 function validateNode(node: Ast.Node): Ast.Node {
@@ -53,20 +53,20 @@ function validateNode(node: Ast.Node): Ast.Node {
 		case 'ns':
 		case 'identifier': {
 			if (reservedWord.includes(node.name)) {
-				throwReservedWordError(node.name);
+				throwReservedWordError(node.name, node.loc);
 			}
 			break;
 		}
 		case 'meta': {
 			if (node.name != null && reservedWord.includes(node.name)) {
-				throwReservedWordError(node.name);
+				throwReservedWordError(node.name, node.loc);
 			}
 			break;
 		}
 		case 'fn': {
 			for (const arg of node.args) {
 				if (reservedWord.includes(arg.name)) {
-					throwReservedWordError(arg.name);
+					throwReservedWordError(arg.name, node.loc);
 				}
 			}
 			break;

--- a/src/parser/scanner.ts
+++ b/src/parser/scanner.ts
@@ -75,7 +75,7 @@ export class Scanner implements ITokenStream {
 	*/
 	public expect(kind: TokenKind): void {
 		if (this.kind !== kind) {
-			throw new AiScriptSyntaxError(`unexpected token: ${TokenKind[this.kind]}`);
+			throw new AiScriptSyntaxError(`unexpected token: ${TokenKind[this.kind]}`, this.token.loc);
 		}
 	}
 
@@ -140,7 +140,7 @@ export class Scanner implements ITokenStream {
 						this.stream.next();
 						token = TOKEN(TokenKind.OpenSharpBracket, loc, { hasLeftSpacing });
 					} else {
-						throw new AiScriptSyntaxError('invalid character: "#"');
+						throw new AiScriptSyntaxError('invalid character: "#"', loc);
 					}
 					break;
 				}
@@ -327,7 +327,7 @@ export class Scanner implements ITokenStream {
 					token = wordToken;
 					break;
 				}
-				throw new AiScriptSyntaxError(`invalid character: "${this.stream.char}"`);
+				throw new AiScriptSyntaxError(`invalid character: "${this.stream.char}"`, loc);
 			}
 			break;
 		}
@@ -432,7 +432,7 @@ export class Scanner implements ITokenStream {
 				this.stream.next();
 			}
 			if (fractional.length === 0) {
-				throw new AiScriptSyntaxError('digit expected');
+				throw new AiScriptSyntaxError('digit expected', loc);
 			}
 		}
 		let value;
@@ -456,7 +456,7 @@ export class Scanner implements ITokenStream {
 			switch (state) {
 				case 'string': {
 					if (this.stream.eof) {
-						throw new AiScriptSyntaxError('unexpected EOF');
+						throw new AiScriptSyntaxError('unexpected EOF', loc);
 					}
 					if (this.stream.char === '\\') {
 						this.stream.next();
@@ -474,7 +474,7 @@ export class Scanner implements ITokenStream {
 				}
 				case 'escape': {
 					if (this.stream.eof) {
-						throw new AiScriptSyntaxError('unexpected EOF');
+						throw new AiScriptSyntaxError('unexpected EOF', loc);
 					}
 					value += this.stream.char;
 					this.stream.next();
@@ -501,7 +501,7 @@ export class Scanner implements ITokenStream {
 				case 'string': {
 					// テンプレートの終了が無いままEOFに達した
 					if (this.stream.eof) {
-						throw new AiScriptSyntaxError('unexpected EOF');
+						throw new AiScriptSyntaxError('unexpected EOF', loc);
 					}
 					// エスケープ
 					if (this.stream.char === '\\') {
@@ -537,7 +537,7 @@ export class Scanner implements ITokenStream {
 				case 'escape': {
 					// エスケープ対象の文字が無いままEOFに達した
 					if (this.stream.eof) {
-						throw new AiScriptSyntaxError('unexpected EOF');
+						throw new AiScriptSyntaxError('unexpected EOF', loc);
 					}
 					// 普通の文字として取り込み
 					buf += this.stream.char;
@@ -549,7 +549,7 @@ export class Scanner implements ITokenStream {
 				case 'expr': {
 					// 埋め込み式の終端記号が無いままEOFに達した
 					if (this.stream.eof) {
-						throw new AiScriptSyntaxError('unexpected EOF');
+						throw new AiScriptSyntaxError('unexpected EOF', loc);
 					}
 					// skip spasing
 					if (spaceChars.includes(this.stream.char)) {

--- a/src/parser/streams/token-stream.ts
+++ b/src/parser/streams/token-stream.ts
@@ -101,7 +101,7 @@ export class TokenStream implements ITokenStream {
 	*/
 	public expect(kind: TokenKind): void {
 		if (this.kind !== kind) {
-			throw new AiScriptSyntaxError(`unexpected token: ${TokenKind[this.kind]}`);
+			throw new AiScriptSyntaxError(`unexpected token: ${TokenKind[this.kind]}`, this.token.loc);
 		}
 	}
 

--- a/src/parser/syntaxes/common.ts
+++ b/src/parser/syntaxes/common.ts
@@ -22,7 +22,7 @@ export function parseParams(s: ITokenStream): { name: string, argType?: Ast.Node
 			if (s.kind === TokenKind.Comma) {
 				s.next();
 			} else if (!s.token.hasLeftSpacing) {
-				throw new AiScriptSyntaxError('separator expected');
+				throw new AiScriptSyntaxError('separator expected', s.token.loc);
 			}
 		}
 
@@ -61,7 +61,7 @@ export function parseBlock(s: ITokenStream): Ast.Node[] {
 		steps.push(parseStatement(s));
 
 		if ((s.kind as TokenKind) !== TokenKind.NewLine && (s.kind as TokenKind) !== TokenKind.CloseBrace) {
-			throw new AiScriptSyntaxError('Multiple statements cannot be placed on a single line.');
+			throw new AiScriptSyntaxError('Multiple statements cannot be placed on a single line.', s.token.loc);
 		}
 		while ((s.kind as TokenKind) === TokenKind.NewLine) {
 			s.next();
@@ -101,7 +101,7 @@ function parseFnType(s: ITokenStream): Ast.Node {
 			if (s.kind === TokenKind.Comma) {
 				s.next();
 			} else if (!s.token.hasLeftSpacing) {
-				throw new AiScriptSyntaxError('separator expected');
+				throw new AiScriptSyntaxError('separator expected', s.token.loc);
 			}
 		}
 		const type = parseType(s);

--- a/src/parser/syntaxes/expressions.ts
+++ b/src/parser/syntaxes/expressions.ts
@@ -70,7 +70,7 @@ function parsePrefix(s: ITokenStream, minBp: number): Ast.Node {
 			if (expr.type === 'num') {
 				return NODE('num', { value: expr.value }, loc);
 			} else {
-				throw new AiScriptSyntaxError('currently, sign is only supported for number literal.');
+				throw new AiScriptSyntaxError('currently, sign is only supported for number literal.', loc);
 			}
 			// TODO: 将来的にサポートされる式を拡張
 			// return NODE('plus', { expr }, loc);
@@ -80,7 +80,7 @@ function parsePrefix(s: ITokenStream, minBp: number): Ast.Node {
 			if (expr.type === 'num') {
 				return NODE('num', { value: -1 * expr.value }, loc);
 			} else {
-				throw new AiScriptSyntaxError('currently, sign is only supported for number literal.');
+				throw new AiScriptSyntaxError('currently, sign is only supported for number literal.', loc);
 			}
 			// TODO: 将来的にサポートされる式を拡張
 			// return NODE('minus', { expr }, loc);
@@ -89,7 +89,7 @@ function parsePrefix(s: ITokenStream, minBp: number): Ast.Node {
 			return NODE('not', { expr }, loc);
 		}
 		default: {
-			throw new AiScriptSyntaxError(`unexpected token: ${TokenKind[op]}`);
+			throw new AiScriptSyntaxError(`unexpected token: ${TokenKind[op]}`, loc);
 		}
 	}
 }
@@ -161,7 +161,7 @@ function parseInfix(s: ITokenStream, left: Ast.Node, minBp: number): Ast.Node {
 				return NODE('or', { left, right }, loc);
 			}
 			default: {
-				throw new AiScriptSyntaxError(`unexpected token: ${TokenKind[op]}`);
+				throw new AiScriptSyntaxError(`unexpected token: ${TokenKind[op]}`, loc);
 			}
 		}
 	}
@@ -186,7 +186,7 @@ function parsePostfix(s: ITokenStream, expr: Ast.Node): Ast.Node {
 			}, loc);
 		}
 		default: {
-			throw new AiScriptSyntaxError(`unexpected token: ${TokenKind[op]}`);
+			throw new AiScriptSyntaxError(`unexpected token: ${TokenKind[op]}`, loc);
 		}
 	}
 }
@@ -231,13 +231,13 @@ function parseAtom(s: ITokenStream, isStatic: boolean): Ast.Node {
 						const exprStream = new TokenStream(element.children!);
 						const expr = parseExpr(exprStream, false);
 						if (exprStream.kind !== TokenKind.EOF) {
-							throw new AiScriptSyntaxError(`unexpected token: ${TokenKind[exprStream.token.kind]}`);
+							throw new AiScriptSyntaxError(`unexpected token: ${TokenKind[exprStream.token.kind]}`, exprStream.token.loc);
 						}
 						values.push(expr);
 						break;
 					}
 					default: {
-						throw new AiScriptSyntaxError(`unexpected token: ${TokenKind[element.kind]}`);
+						throw new AiScriptSyntaxError(`unexpected token: ${TokenKind[element.kind]}`, element.loc);
 					}
 				}
 			}
@@ -283,7 +283,7 @@ function parseAtom(s: ITokenStream, isStatic: boolean): Ast.Node {
 			return expr;
 		}
 	}
-	throw new AiScriptSyntaxError(`unexpected token: ${TokenKind[s.kind]}`);
+	throw new AiScriptSyntaxError(`unexpected token: ${TokenKind[s.kind]}`, loc);
 }
 
 /**
@@ -301,7 +301,7 @@ function parseCall(s: ITokenStream, target: Ast.Node): Ast.Node {
 			if (s.kind === TokenKind.Comma) {
 				s.next();
 			} else if (!s.token.hasLeftSpacing) {
-				throw new AiScriptSyntaxError('separator expected');
+				throw new AiScriptSyntaxError('separator expected', s.token.loc);
 			}
 		}
 
@@ -451,11 +451,11 @@ function parseReference(s: ITokenStream): Ast.Node {
 		if (segs.length > 0) {
 			if (s.kind === TokenKind.Colon) {
 				if (s.token.hasLeftSpacing) {
-					throw new AiScriptSyntaxError('Cannot use spaces in a reference.');
+					throw new AiScriptSyntaxError('Cannot use spaces in a reference.', s.token.loc);
 				}
 				s.next();
 				if (s.token.hasLeftSpacing) {
-					throw new AiScriptSyntaxError('Cannot use spaces in a reference.');
+					throw new AiScriptSyntaxError('Cannot use spaces in a reference.', s.token.loc);
 				}
 			} else {
 				break;
@@ -505,7 +505,7 @@ function parseObject(s: ITokenStream, isStatic: boolean): Ast.Node {
 			// noop
 		} else {
 			if (!s.token.hasLeftSpacing) {
-				throw new AiScriptSyntaxError('separator expected');
+				throw new AiScriptSyntaxError('separator expected', s.token.loc);
 			}
 		}
 
@@ -546,7 +546,7 @@ function parseArray(s: ITokenStream, isStatic: boolean): Ast.Node {
 			// noop
 		} else {
 			if (!s.token.hasLeftSpacing) {
-				throw new AiScriptSyntaxError('separator expected');
+				throw new AiScriptSyntaxError('separator expected', s.token.loc);
 			}
 		}
 

--- a/src/parser/syntaxes/statements.ts
+++ b/src/parser/syntaxes/statements.ts
@@ -72,7 +72,7 @@ export function parseDefStatement(s: ITokenStream): Ast.Node {
 			return parseFnDef(s);
 		}
 		default: {
-			throw new AiScriptSyntaxError(`unexpected token: ${TokenKind[s.kind]}`);
+			throw new AiScriptSyntaxError(`unexpected token: ${TokenKind[s.kind]}`, s.token.loc);
 		}
 	}
 }
@@ -112,7 +112,7 @@ function parseVarDef(s: ITokenStream): Ast.Node {
 			break;
 		}
 		default: {
-			throw new AiScriptSyntaxError(`unexpected token: ${TokenKind[s.kind]}`);
+			throw new AiScriptSyntaxError(`unexpected token: ${TokenKind[s.kind]}`, s.token.loc);
 		}
 	}
 	s.next();
@@ -213,7 +213,7 @@ function parseEach(s: ITokenStream): Ast.Node {
 	if (s.kind === TokenKind.Comma) {
 		s.next();
 	} else if (!s.token.hasLeftSpacing) {
-		throw new AiScriptSyntaxError('separator expected');
+		throw new AiScriptSyntaxError('separator expected', s.token.loc);
 	}
 
 	const items = parseExpr(s, false);
@@ -263,7 +263,7 @@ function parseFor(s: ITokenStream): Ast.Node {
 		if ((s.kind as TokenKind) === TokenKind.Comma) {
 			s.next();
 		} else if (!s.token.hasLeftSpacing) {
-			throw new AiScriptSyntaxError('separator expected');
+			throw new AiScriptSyntaxError('separator expected', s.token.loc);
 		}
 
 		const to = parseExpr(s, false);
@@ -326,7 +326,7 @@ function parseStatementWithAttr(s: ITokenStream): Ast.Node {
 	const statement = parseStatement(s);
 
 	if (statement.type !== 'def') {
-		throw new AiScriptSyntaxError('invalid attribute.');
+		throw new AiScriptSyntaxError('invalid attribute.', statement.loc);
 	}
 	if (statement.attr != null) {
 		statement.attr.push(...attrs);

--- a/src/parser/syntaxes/toplevel.ts
+++ b/src/parser/syntaxes/toplevel.ts
@@ -36,7 +36,7 @@ export function parseTopLevel(s: ITokenStream): Ast.Node[] {
 		}
 
 		if ((s.kind as TokenKind) !== TokenKind.NewLine && (s.kind as TokenKind) !== TokenKind.EOF) {
-			throw new AiScriptSyntaxError('Multiple statements cannot be placed on a single line.');
+			throw new AiScriptSyntaxError('Multiple statements cannot be placed on a single line.', s.token.loc);
 		}
 		while ((s.kind as TokenKind) === TokenKind.NewLine) {
 			s.next();
@@ -82,7 +82,7 @@ export function parseNamespace(s: ITokenStream): Ast.Node {
 		}
 
 		if ((s.kind as TokenKind) !== TokenKind.NewLine && (s.kind as TokenKind) !== TokenKind.CloseBrace) {
-			throw new AiScriptSyntaxError('Multiple statements cannot be placed on a single line.');
+			throw new AiScriptSyntaxError('Multiple statements cannot be placed on a single line.', s.token.loc);
 		}
 		while ((s.kind as TokenKind) === TokenKind.NewLine) {
 			s.next();

--- a/src/type.ts
+++ b/src/type.ts
@@ -151,7 +151,7 @@ export function getTypeBySource(typeSource: Ast.TypeSource): Type {
 				return T_GENERIC(typeSource.name, [innerType]);
 			}
 		}
-		throw new AiScriptSyntaxError(`Unknown type: '${getTypeNameBySource(typeSource)}'`);
+		throw new AiScriptSyntaxError(`Unknown type: '${getTypeNameBySource(typeSource)}'`, typeSource.loc);
 	} else {
 		const argTypes = typeSource.args.map(arg => getTypeBySource(arg));
 		return T_FN(argTypes, getTypeBySource(typeSource.result));


### PR DESCRIPTION
<!-- ℹ お読みください
PRありがとうございます！ PRを作成する前に、以下をご確認ください:
- 可能であればタイトルに、以下で示すようなPRの種類が分かるキーワードをプリフィクスしてください。
  - fix / refactor / feat / enhance / perf / chore
  - また、PRの粒度が適切であることを確認してください。ひとつのPRに複数の種類の変更や関心を含めることは避けてください。
- このPRによって解決されるIssueがある場合は、そのIssueへの参照を本文内に含めてください。
- CHANGELOG.mdに変更点を追記してください。リファクタリングなど、利用者に影響を与えない変更についてはこの限りではありません。
- この変更により新たに作成、もしくは更新すべきドキュメントがないか確認してください。
- 機能追加やバグ修正をした場合は、可能であればテストケースを追加してください。
- テスト、Lintが通っていることを予め確認してください。
  - `npm run test`、`npm run lint`でぞれぞれ実施可能です
- `npm run api`を実行してAPIレポートを更新し、差分がある場合はコミットしてください。
ご協力ありがとうございます🤗
-->
<!-- ℹ README
Thank you for your PR! Before creating a PR, please check the following:
- If possible, prefix the title with a keyword that identifies the type of this PR, as shown below.
  - fix / refactor / feat / enhance / perf / chore
  - Also, make sure that the granularity of this PR is appropriate. Please do not include more than one type of change or interest in a single PR.
- If there is an Issue which will be resolved by this PR, please include a reference to the Issue in the text.
- Please add the summary of the changes to CHANGELOG.md. However, this is not necessary for changes that do not affect the users, such as refactoring.
- Check if there are any documents that need to be created or updated due to this change.
- If you have added a feature or fixed a bug, please add a test case if possible.
- Please make sure that tests and Lint are passed in advance.
  - You can run it with `npm run test` and `npm run lint`.
- Run `npm run api` to update the API report and commit it if there are any diffs.
Thanks for your cooperation 🤗
-->

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
- 文法エラーで行番号と列番号が表示されるようになります。
- 型エラーのコンストラクタにもlocパラメータを追加。


関連 #144 

# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
